### PR TITLE
Suppress branch_protection bugs

### DIFF
--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,1 @@
+action: log


### PR DESCRIPTION
`allstar` does not support the new branch protection syntax, only 'legacy' rules.

So in order to fix #1 we need to suppress issue creation.